### PR TITLE
Fix BMI entry flow and retake links

### DIFF
--- a/assessment-result.html
+++ b/assessment-result.html
@@ -185,7 +185,7 @@
 
     function retakeTest() {
       if (currentTestType === 'bmi') {
-        window.location.href = 'assessment-test.html?type=bmi';
+        window.location.href = 'self-assessment.html?type=bmi';
       } else if (currentTestType === 'anxiety') {
         window.location.href = 'assessment-test.html?type=anxiety';
       } else {
@@ -337,7 +337,7 @@
           <h3 class="text-xl font-semibold text-primary mb-2">无法显示测评结果</h3>
           <p class="text-gray-500 mb-6">请重新进行测评以获取结果</p>
           <div class="flex flex-col sm:flex-row gap-4 justify-center">
-            <button onclick="window.location.href='assessment-test.html?type=bmi'" class="btn-primary text-white px-6 py-3 rounded-lg">
+            <button onclick="window.location.href='self-assessment.html?type=bmi'" class="btn-primary text-white px-6 py-3 rounded-lg">
               <span class="mr-2">⚖️</span>BMI测评
             </button>
             <button onclick="window.location.href='assessment-test.html?type=anxiety'" class="btn-primary text-white px-6 py-3 rounded-lg">

--- a/assessment-test.html
+++ b/assessment-test.html
@@ -427,9 +427,7 @@
       
       // 根据测评类型调整页面（如果需要支持多种测评类型）
       if (testType === 'bmi') {
-        // 如果是BMI测评，可以重定向到BMI测评页面
-        // 或者在这里实现BMI测评逻辑
-        window.location.href = 'bmi-assessment.html';
+        window.location.href = 'self-assessment.html?type=bmi';
         return;
       }
       

--- a/self-assessment.html
+++ b/self-assessment.html
@@ -601,15 +601,29 @@
       // 检查是否有传入的测评类型参数
       const urlParams = new URLSearchParams(window.location.search);
       const testType = urlParams.get('type');
-      
-      // 根据测评类型调整页面（如果需要支持多种测评类型）
+      const bmiSection = document.getElementById('bmiSection');
+      const anxietySection = document.getElementById('anxietySection');
+
       if (testType === 'bmi') {
-        // 如果是BMI测评，可以重定向到BMI测评页面
-        // 或者在这里实现BMI测评逻辑
-        window.location.href = 'bmi-assessment.html';
+        if (bmiSection) {
+          bmiSection.style.display = 'block';
+        }
+        if (anxietySection) {
+          anxietySection.style.display = 'none';
+        }
+
+        initBMIAssessment();
+        showToast('请输入您的基础信息以查看 BMI 结果');
         return;
       }
-      
+
+      if (bmiSection) {
+        bmiSection.style.display = 'none';
+      }
+      if (anxietySection) {
+        anxietySection.style.display = 'block';
+      }
+
       // 默认进行身材焦虑测评
       initAssessment();
       showToast('开始测评，请根据实际情况如实回答');


### PR DESCRIPTION
## Summary
- update the self assessment loader to show the BMI form inline and initialize the BMI calculator
- route BMI test entries from the legacy assessment page into the unified self-assessment view
- update BMI retake and error recovery buttons to link to the working entry point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6bb406a1c8324abeace59113bba45